### PR TITLE
fix maven warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
         <surefire.version>2.19.1</surefire.version>
 
         <test.file></test.file>


### PR DESCRIPTION
Maven source 1.6 causes a compilation error and build failure.

"Source option 6 is no longer supported. Use 7 or later"

Updating pom.xml to use maven source 1.7.