### PR TITLE
fix for rare failure on some motorola devices

### DIFF
--- a/src/test/java/com/browserstack/SingleTest.java
+++ b/src/test/java/com/browserstack/SingleTest.java
@@ -5,17 +5,27 @@ import org.openqa.selenium.WebElement;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.openqa.selenium.JavascriptExecutor;
 
 public class SingleTest extends BrowserStackTestNGTest {
 
     @Test
     public void test() throws Exception {
         driver.get("https://www.google.com/ncr");
+        try {
+            WebElement ele = driver.findElement(By.className("IKl7Q"));
+            if(ele.isDisplayed()) {
+                ((JavascriptExecutor)driver).executeScript("arguments[0].scrollTo(0, arguments[0].scrollHeight)",ele);
+                driver.findElement(By.xpath("//*[@id='L2AGLb']/div")).click();
+            }
+        }
+        catch(Exception e){
+            System.out.print(e);
+        }
         WebElement element = driver.findElement(By.name("q"));
         element.sendKeys("BrowserStack");
         element.submit();
         Thread.sleep(5000);
-
         Assert.assertEquals("BrowserStack - Google Search", driver.getTitle());
     }
 }


### PR DESCRIPTION
added try catch block for finding element of modal class which is opening rarely for some devices and clicking on i agree to continue with the existing flow