### PR TITLE
fix: assert case insensitive for ie browsers

### DIFF
--- a/src/test/java/com/browserstack/SingleTest.java
+++ b/src/test/java/com/browserstack/SingleTest.java
@@ -16,6 +16,6 @@ public class SingleTest extends BrowserStackTestNGTest {
         element.submit();
         Thread.sleep(5000);
 
-        Assert.assertEquals("BrowserStack - Google Search", driver.getTitle());
+        Assert.assertTrue(driver.getTitle().matches("(?i)BrowserStack - Google Search"));
     }
 }


### PR DESCRIPTION
https://browserstack.atlassian.net/browse/ACE-2219
testng-browserstack Passing the test cases for the mentioned below sample devices.
iPhone 8 - pass
Samsung Galaxy S10 Plus - pass
Samsung Galaxy S7 - pass
iPhone 6S - pass
OnePlus 9 - pass
iPad Air 4 - pass
Google Pixel 5 - pass
Xiaomi Redmi Note 9 - pass
iPhone SE 2020 - pass
Oppo Reno 3 Pro - pass
iPad Mini 4 - pass
Samsung Galaxy A51 - pass
iPhone XS - pass
iPhone 12 Pro Max - pass
Other Browsers -
Chrome on win7/8/8.1/10/mac - pass
Firefox on win7/8/8.1/10/mac - pass
ie on win7/8/8.1/10 - pass
edge on win10 - pass
safari 12.1 on mojave/13.1 on catalina - pass
tested by @SyedSaifAli